### PR TITLE
Fix chapter2 protocols code example typo

### DIFF
--- a/chapter2/21_Protocols.md
+++ b/chapter2/21_Protocols.md
@@ -98,7 +98,7 @@ class Starship: FullyNamed {
 	var prefix: String?
 	var name: String
 	init(name: String, prefix: String? = nil ) {
-		self.anme = name
+		self.name = name
 		self.prefix = prefix
 	}
 	var fullName: String {


### PR DESCRIPTION
`anme` -> `name`
